### PR TITLE
妨害機能、シューティング用サーボの追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(minimalists
         src/disturbance_observer.cpp
         src/low_pass_filter.cpp
         src/trajectory.cpp
+		src/servo.cpp
         )
 
 # Add pico_multicore which is required for multicore functionality

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -238,6 +238,8 @@ constexpr int32_t RIGHT_DEPLOY_2ND = -27046;  // 右展開2段階(最奥)
 // dynamixelのID
 constexpr short DXL_ID_LEFT = 0x03;   // 左展開
 constexpr short DXL_ID_RIGHT = 0x04;  // 右展開
+// 電流制限
+constexpr uint16_t DISTURBANCE_CURRENT_LIMIT = 500;  // 電流制限 [mA]
 }  // namespace DisturbanceConfig
 
 namespace FastArmConfig {

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -24,7 +24,7 @@ constexpr float PI_F = 3.14159265358979323846f;
 // pin
 constexpr uint8_t UART0_TX_PIN = 0;
 constexpr uint8_t UART0_RX_PIN = 1;
-constexpr uint8_t UART0_DE_RE_PIN = 2;
+constexpr uint8_t UART0_DE_RE_PIN = 2;  // 最速アーム
 constexpr uint8_t UART1_TX_PIN = 4;
 constexpr uint8_t UART1_RX_PIN = 5;
 constexpr uint8_t UART1_DE_RE_PIN = 20;
@@ -198,7 +198,7 @@ constexpr float P_VELOCITY_GAIN = 2.0f * sqrtf_P_POSITION_GAIN;                 
 }  // namespace ControlConfig
 
 // ======== Dynamixelの設定 ========
-namespace DynamixelConfig {
+namespace HandConfig {
 // PIN設定
 constexpr int PUMP_PIN = 21;
 constexpr int SOLENOID_PIN = 22;
@@ -223,11 +223,24 @@ constexpr float START = 90.0f;
 // dynamixelのID
 constexpr short DXL_ID1 = 0x01;  // 手先
 constexpr short DXL_ID2 = 0x02;  // 昇降
-}  // namespace DynamixelConfig
+}  // namespace HandConfig
+
+// ======= 妨害設定 ========
+namespace DisturbanceConfig {
+constexpr int32_t LEFT_DEPLOY_PRE = 1117;     // 左展開前
+constexpr int32_t LEFT_DEPLOY_1ST = 19872;    // 左展開1段階
+constexpr int32_t LEFT_DEPLOY_2ND = 30246;    // 左展開2段階(最奥)
+constexpr int32_t RIGHT_DEPLOY_PRE = 2085;    // 右展開前
+constexpr int32_t RIGHT_DEPLOY_1ST = -16852;  // 右展開1段階
+constexpr int32_t RIGHT_DEPLOY_2ND = -27046;  // 右展開2段階(最奥)
+
+// dynamixelのID
+constexpr short DXL_ID_LEFT = 0x03;   // 左展開
+constexpr short DXL_ID_RIGHT = 0x04;  // 右展開
+}  // namespace DisturbanceConfig
 
 namespace FastArmConfig {
 // ピン設定
 constexpr uint8_t SOLENOID_PIN = 17;
 constexpr uint8_t PUMP_PIN = 3;
-
 }  // namespace FastArmConfig

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -33,10 +33,11 @@ namespace LED {
 constexpr uint8_t ALIVE_PIN = 18;
 constexpr uint8_t ERROR_PIN = 19;
 }  // namespace LED
-namespace Servo {
-constexpr uint8_t UPPER_PIN = 12;
-constexpr uint8_t LOWER_PIN = 15;
-}  // namespace Servo
+namespace ShootingConfig {
+constexpr uint8_t SERVO_PIN = 12;
+constexpr float IDLE_ANGLE = 0.0f;         // 待機時の角度
+constexpr float CORRECTION_ANGLE = 90.0f;  // ワークの姿勢を整えるときの角度
+}  // namespace ShootingConfig
 
 // 軌道データ点の構造体（制御用の詳細軌道）
 typedef struct {

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -22,6 +22,7 @@
 constexpr float PI_F = 3.14159265358979323846f;
 
 // pin
+constexpr uint8_t BUTTON_PIN = 15;
 constexpr uint8_t UART0_TX_PIN = 0;
 constexpr uint8_t UART0_RX_PIN = 1;
 constexpr uint8_t UART0_DE_RE_PIN = 2;  // 最速アーム

--- a/include/servo.hpp
+++ b/include/servo.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "hardware/pwm.h"
+#include "pico/stdlib.h"
+
+class Servo {
+   public:
+    explicit Servo(uint pin);        // コンストラクタ
+    void set_pulse_us(uint16_t us);  // パルス幅を直接指定（μs単位）
+    void set_angle(float degree);    // 角度指定（0〜180°）
+
+   private:
+    uint pin_;
+    uint slice_num_;
+    uint channel_;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -418,7 +418,7 @@ void handle_disturbance_trigger() {
     }
     last_button_press_time = now;
 
-    // 妨害レベルを 0 -> 1 -> 2 -> 0 -> ... と変化させる
+    // 妨害レベルを変化させる
     g_disturbance_level = (g_disturbance_level + 1) % 2;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "config.hpp"
 #include "dynamixel.hpp"
+#include "servo.hpp"
 #include "trajectory.hpp"
 #include "trajectory_sequence_manager.hpp"
 
@@ -34,6 +35,8 @@ AMT223V_Manager encoder_manager(SPI1_CONFIG.spi_port, SPI1_CONFIG.pin_miso, SPI1
 // RoboMasterモータオブジェクト
 robomaster_motor_t motor1(&can, 1, Mech::gear_ratio_R);  // motor_id=1
 robomaster_motor_t motor2(&can, 2, Mech::gear_ratio_P);  // motor_id=2
+
+Servo shooting_servo(ShootingConfig::SERVO_PIN);
 
 float clampTorque(float torque, float max_torque) {
     if (torque > max_torque) {
@@ -998,6 +1001,18 @@ int main(void) {
                     break;
             }
             prev_disturbance_level = g_disturbance_level;  // 状態を更新
+        }
+
+        // シューティングエリアのサーボを3秒に1回動かす
+        static absolute_time_t last_shoot_servo_time = {0};
+        if (absolute_time_diff_us(last_shoot_servo_time, get_absolute_time()) >= 3'000'000 &&
+            absolute_time_diff_us(last_shoot_servo_time, get_absolute_time()) < 6'000'000) {
+            g_debug_manager->debug("Set shooting servo angle to correction angle.");
+            shooting_servo.set_angle(ShootingConfig::CORRECTION_ANGLE);
+        } else if (absolute_time_diff_us(last_shoot_servo_time, get_absolute_time()) >= 6'000'000) {
+            g_debug_manager->debug("Set shooting servo angle to idle angle.");
+            shooting_servo.set_angle(ShootingConfig::IDLE_ANGLE);
+            last_shoot_servo_time = get_absolute_time();
         }
 
         // FIFOから同期信号を待機（ブロッキング）

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -989,16 +989,12 @@ int main(void) {
                 case 0:  // 1段階目に戻す
                     g_debug_manager->info("Disturbance deploying to 1st stage.");
                     control_position_multiturn(&UART1, Dist::DXL_ID_LEFT, Dist::LEFT_DEPLOY_1ST);
-                    sleep_ms(100);
                     control_position_multiturn(&UART1, Dist::DXL_ID_RIGHT, Dist::RIGHT_DEPLOY_1ST);
-                    sleep_ms(100);
                     break;
                 case 1:  // 2段階目
                     g_debug_manager->info("Disturbance deploying to 2nd stage.");
                     control_position_multiturn(&UART1, Dist::DXL_ID_LEFT, Dist::LEFT_DEPLOY_2ND);
-                    sleep_ms(100);
                     control_position_multiturn(&UART1, Dist::DXL_ID_RIGHT, Dist::RIGHT_DEPLOY_2ND);
-                    sleep_ms(100);
                     break;
             }
             prev_disturbance_level = g_disturbance_level;  // 状態を更新

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1005,14 +1005,15 @@ int main(void) {
 
         // シューティングエリアのサーボを3秒に1回動かす
         static absolute_time_t last_shoot_servo_time = {0};
-        if (absolute_time_diff_us(last_shoot_servo_time, get_absolute_time()) >= 3'000'000 &&
-            absolute_time_diff_us(last_shoot_servo_time, get_absolute_time()) < 6'000'000) {
+        absolute_time_t now = get_absolute_time();
+        if (absolute_time_diff_us(last_shoot_servo_time, now) >= 3'000'000 &&
+            absolute_time_diff_us(last_shoot_servo_time, now) < 6'000'000) {
             g_debug_manager->debug("Set shooting servo angle to correction angle.");
             shooting_servo.set_angle(ShootingConfig::CORRECTION_ANGLE);
-        } else if (absolute_time_diff_us(last_shoot_servo_time, get_absolute_time()) >= 6'000'000) {
+        } else if (absolute_time_diff_us(last_shoot_servo_time, now) >= 6'000'000) {
             g_debug_manager->debug("Set shooting servo angle to idle angle.");
             shooting_servo.set_angle(ShootingConfig::IDLE_ANGLE);
-            last_shoot_servo_time = get_absolute_time();
+            last_shoot_servo_time = now;
         }
 
         // FIFOから同期信号を待機（ブロッキング）

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1004,7 +1004,7 @@ int main(void) {
         }
 
         // シューティングエリアのサーボを3秒に1回動かす
-        static absolute_time_t last_shoot_servo_time = {0};
+        static absolute_time_t last_shoot_servo_time = get_absolute_time();
         absolute_time_t now = get_absolute_time();
         if (absolute_time_diff_us(last_shoot_servo_time, now) >= 3'000'000 &&
             absolute_time_diff_us(last_shoot_servo_time, now) < 6'000'000) {

--- a/src/servo.cpp
+++ b/src/servo.cpp
@@ -17,7 +17,7 @@ Servo::Servo(uint pin) : pin_(pin) {
 
 void Servo::set_pulse_us(uint16_t us) {
     // 1カウント = 20ms / 25000 = 0.8us
-    uint16_t level = static_cast<uint16_t>(us / 0.8f);
+    uint16_t level = static_cast<uint16_t>(us * 1.25f);
     pwm_set_chan_level(slice_num_, channel_, level);
 }
 

--- a/src/servo.cpp
+++ b/src/servo.cpp
@@ -1,0 +1,30 @@
+#include "servo.hpp"
+
+Servo::Servo(uint pin) : pin_(pin) {
+    // ピンをPWM機能に設定
+    gpio_set_function(pin_, GPIO_FUNC_PWM);
+
+    // PWMスライスを取得
+    slice_num_ = pwm_gpio_to_slice_num(pin_);
+    channel_ = pwm_gpio_to_channel(pin_);
+
+    // 20ms周期(50Hz)のPWMを設定
+    pwm_set_wrap(slice_num_, 24999);                 // TOP値
+    pwm_set_clkdiv(slice_num_, 100.0f);              // 分周設定
+    pwm_set_chan_level(slice_num_, channel_, 1875);  // 初期値：1.5ms (90°)
+    pwm_set_enabled(slice_num_, true);
+}
+
+void Servo::set_pulse_us(uint16_t us) {
+    // 1カウント = 20ms / 25000 = 0.8us
+    uint16_t level = static_cast<uint16_t>(us / 0.8f);
+    pwm_set_chan_level(slice_num_, channel_, level);
+}
+
+void Servo::set_angle(float degree) {
+    // サーボによって異なるが一般的に 1ms=0°, 2ms=180°
+    const float min_us = 1000.0f;
+    const float max_us = 2000.0f;
+    float us = min_us + (degree / 180.0f) * (max_us - min_us);
+    set_pulse_us(static_cast<uint16_t>(us));
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 要件
妨害機構をボタンの押下によって展開するようにしました。
初期化の段階で中間位置まで出て、以降はボタンを押すたびに最奥位置と中間位置を行き来します。

また、シューティング用のサーボモータのプログラムを実装しました。
3秒ごとにサーボを上げ下げします。

## テスト項目

- [x] アームとの同時動作

## 留意事項
#29 のとおり、手先がたまに上がらないことがあります。

<!-- for GitHub Copilot review rule -->
<!--
When reviewing, please use the following prefixes:
[must]  
[imo] (in my opinion)  
[nits] (nitpick)  
[ask]  
[fyi]
-->
<!-- 
In this project, we follow the Raspberry Pi Pico SDK (pico-sdk) naming conventions as below:

- **Function, variable, and struct names**  
  Use lower_snake_case (e.g., `motor_speed`, `core1_entry`, `robot_state_t`).  
  Struct and type names should end with `_t`.

- **Macros and constants**  
  Use UPPER_SNAKE_CASE (e.g., `MAX_SPEED`, `PICO_DEFAULT_LED_PIN`).

- **Global variables**  
  Use lower_snake_case with a `g_` prefix to avoid conflicts (e.g., `g_robot_state`).
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->